### PR TITLE
Adding MR template to standardize merge requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## 📝 Summary
+Explain the purpose of this MR:
+- What problem does it solve?
+- What feature or fix is introduced?
+
+---
+
+## ✅ Changes Made
+List key changes (high-level):
+- Added `<feature/endpoint/component>`
+- Fixed `<bug/issue>`
+- Updated `<documentation/tests>`
+
+---
+
+## 🎯 Related Issues
+- Closes `#<issue_number>`
+
+---
+
+## 📷 Screenshots / Demo (if applicable)
+_Attach images, GIFs, or terminal outputs here._
+
+---
+
+## 📚 Notes for Reviewers
+_Add any context reviewers should know (design decisions, trade-offs, limitations)._
+
+---
+
+## 👀 Checklist (Author & Reviewer)
+- [ ] Code follows project style guidelines
+- [ ] Documentation updated (README, API docs, comments)
+- [ ] Tests written and passing
+- [ ] No unnecessary commits or debug code


### PR DESCRIPTION
## 📝 Summary
- Standardizing merge request descriptions for everyone on the team. 

---

## ✅ Changes Made
List key changes (high-level):
- Added `pull_request_template.md` file that specifies the MR details needed.

---

## 👀 Checklist (Author & Reviewer)
- [X] Code follows project style guidelines
- [X] Documentation updated (README, API docs, comments)
- [ ] Tests written and passing
- [X] No unnecessary commits or debug code
