### PR TITLE
issue #62 - Attempt to fix pipeline fail issue with push restriction

### DIFF
--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -2,11 +2,13 @@ name: buildtex
 
 on:
   push:
-    branches: main
-    paths: [docs/**]
-  pull_request:
-    branches: main
-    paths: [docs/**]
+    branches:
+      - '**'
+  #   branches: main
+  #   paths: [docs/**]
+  # pull_request:
+  #   branches: main
+  #   paths: [docs/**]
 
 permissions:
   contents: write
@@ -15,9 +17,23 @@ jobs:
   compile-latex:
     runs-on: ubuntu-latest
     steps:
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOTVARIABLE}}
+          private-key: ${{ secrets.BOTSECRET }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set User
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Get changed LaTeX files
         id: latex-files
         run: |

--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -2,13 +2,11 @@ name: buildtex
 
 on:
   push:
-    branches:
-      - '**'
-  #   branches: main
-  #   paths: [docs/**]
-  # pull_request:
-  #   branches: main
-  #   paths: [docs/**]
+    branches: main
+    paths: [docs/**]
+  pull_request:
+    branches: main
+    paths: [docs/**]
 
 permissions:
   contents: write
@@ -17,23 +15,19 @@ jobs:
   compile-latex:
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
           app-id: ${{ vars.BOTVARIABLE}}
           private-key: ${{ secrets.BOTSECRET }}
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-
       - name: Set User
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: Get changed LaTeX files
         id: latex-files
         run: |


### PR DESCRIPTION
## 📝 Summary
- This PR aims to fix the build error we are getting across various PRs and main. The issue stems from the fact that github-actions[bot] cannot be added as a bypass user under branch protection. Because of this this, it always throws the error that a PR must be created before merge can be completed.
- Adding a github app bot fixes this issue, since it can be added as a "user" for bypassing. This PR involves updating the build yml file to include the github app (that I created) user credentials.

---

## 🎯 Related Issues
- Closes `#62`

---

## 👀 Checklist (Author & Reviewer)
- [X] Code follows project style guidelines
- [ ] Documentation updated (README, API docs, comments)
- [ ] Tests written and passing
- [X] No unnecessary commits or debug code
