### PR TITLE
[#130] CI trigger on changes to only code files

### DIFF
--- a/.github/workflows/buildsrc.yml
+++ b/.github/workflows/buildsrc.yml
@@ -3,8 +3,14 @@ name: ARM GCC Build
 on:
   push:
     branches: [ main ]
+    paths: 
+      - 'src/**/*.{c,cpp,h,hpp}'
+      - 'test/**/*.{c,cpp,h,hpp}'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**/*.{c,cpp,h,hpp}'
+      - 'test/**/*.{c,cpp,h,hpp}'
 
 jobs:
   build:

--- a/.github/workflows/buildsrc.yml
+++ b/.github/workflows/buildsrc.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [ main ]
     paths: 
-      - 'src/**/*.{c,cpp,h,hpp}'
-      - 'test/**/*.{c,cpp,h,hpp}'
+      - 'src/**'
+      - 'test/**'
+      - '**/CMakeLists.txt'
   pull_request:
     branches: [ main ]
     paths:
-      - 'src/**/*.{c,cpp,h,hpp}'
-      - 'test/**/*.{c,cpp,h,hpp}'
+      - 'src/**'
+      - 'test/**'
+      - '**/CMakeLists.txt'
 
 jobs:
   build:


### PR DESCRIPTION
## 📝 Summary

https://github.com/Team6-SixSense/audio360/pull/131 added CI for building source code for PRs. However, the CI is being triggered for every PR, even if the PR is just to update documentation. This PR is to specify the trigger for this CI job to only trigger when software files are changed in the PR.


## 🎯 Related Issues

- #130 
