### PR TITLE
[FIX] Attempt improve builder CI to build all .tex file changes recursively

### DIFF
--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get changed LaTeX files
         id: latex-files
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- docs/**/*.tex | xargs)
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep '^docs/.*\.tex$' || true)
           echo "Changed files: $CHANGED_FILES"
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
           CHANGED_FILENAMES=$(for file in $CHANGED_FILES; do basename "$file"; done | xargs)

--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -42,6 +42,7 @@
 
 \maketitle
 
+
 \pagenumbering{roman}
 
 \section{Revision History}


### PR DESCRIPTION
## 📝 Summary

The current GitHub Actions CI will not build .tex files recursively. That means, design documents are not currently being fixed. This PR is to update the github action to look for .tex file changes recursively and build the pdf.

## 🎯 Related Issues
None 
