### PR TITLE
[HOTFIX] fix CI builder for multi file changes

### DIFF
--- a/.github/workflows/buildtex.yml
+++ b/.github/workflows/buildtex.yml
@@ -33,7 +33,11 @@ jobs:
         run: |
           CHANGED_FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep '^docs/.*\.tex$' || true)
           echo "Changed files: $CHANGED_FILES"
-          echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
+          {
+            echo "CHANGED_FILES<<EOF"
+            echo "$CHANGED_FILES"
+            echo "EOF"
+          } >> $GITHUB_ENV
           CHANGED_FILENAMES=$(for file in $CHANGED_FILES; do basename "$file"; done | xargs)
           echo "CHANGED_FILENAMES=$CHANGED_FILENAMES" >> $GITHUB_ENV
           FILE_COUNT=$(echo $CHANGED_FILENAMES | wc -w)

--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -35,7 +35,6 @@
 \newcommand{\mref}[1]{M\ref{#1}}
 
 \begin{document}
-
 \title{Module Guide for \progname{}} 
 \author{\authname}
 \date{\today}

--- a/docs/Design/SoftDetailedDes/MIS.tex
+++ b/docs/Design/SoftDetailedDes/MIS.tex
@@ -39,7 +39,6 @@ urlcolor=cyan          % color of external links
 \input{../../Common}
 
 \begin{document}
-
 \title{Module Interface Specification for \progname{}}
 
 \author{\authname}

--- a/docs/SRS/SRS.tex
+++ b/docs/SRS/SRS.tex
@@ -19,7 +19,6 @@
 \usepackage{afterpage}
 \usepackage{cite}
 
-
 \hypersetup{ bookmarks=true,         % show bookmarks bar?
       colorlinks=true,       % false: boxed links; true: colored links
     linkcolor=red,          % color of internal links 

--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -31,7 +31,6 @@
 \date{\today}
 	
 \maketitle
-
 \pagenumbering{roman}
 
 \section*{Revision History}


### PR DESCRIPTION
## 📝 Summary

CI builder fails to build PDF when there are multiple files being built in a single change

## 🎯 Related Issues

No issue created, this is hot fix