### PR TITLE
[#273] Peer feedback integration - added mention of high low priority with numbers being examples only

### DIFF
--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -532,9 +532,9 @@ system.
 					
 \textbf{Input:}
 Three concurrent tasks submitted to the firmware scheduler: Task A with high
-priority (priority level 1), Task B with medium priority (priority level 5), and
-Task C with low priority (priority level 10). Execution order is recorded to 
-determine the task start sequence.
+priority (ex. priority level 1), Task B with medium priority (ex. priority level
+ 5), and Task C with low priority (ex. priority level 10). Execution order is 
+ recorded to determine the task start sequence.
 					
 \textbf{Output:}
 Execution logs show that tasks execute in priority order: Task A starts first,


### PR DESCRIPTION
…- addresses peer review feedback

## 📝 Summary

Added the explicit mention that the numbers for priority are just suggestions and the terms high, low, and medium priority are to be used instead as per peer review feedback 


## 🎯 Related Issues

- closes #273
