### PR TITLE
[#363] Removing ADC tests since microphones come with them

### DIFF
--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -697,13 +697,13 @@ application with driver API access is ready to execute.
 					
 \textbf{Input:}
 A test sequence that invokes driver API functions for different hardware
-operations: (1) read from ADC channel, (2) write to GPIO pin, (3) configure
-timer, (4) read system clock. Each operation uses the driver's abstracted
+operations: (1) write to GPIO pin, (2) configure
+timer, (3) read system clock. Each operation uses the driver's abstracted
 interface rather than direct hardware register access.
 					
 \textbf{Output:}
-All driver API calls complete successfully and return expected data. ADC reads
-return valid voltage samples. GPIO writes toggle pin states visible on
+All driver API calls complete successfully and return expected data.
+GPIO writes toggle pin states visible on
 oscilloscope. Timer configuration produces expected timing behavior. System
 clock reads return monotonically increasing timestamps. 
 
@@ -717,8 +717,8 @@ functionality for all hardware operations required by application components.
 Compile test application that uses only driver API calls (no direct register
 access). Deploy to microcontroller. Execute test sequence exercising each driver
 function. Verify all operations complete successfully through return codes. Use
-oscilloscope to verify GPIO toggles. Use serial logging to verify ADC readings
-are within expected ranges. The test passes if all driver operations execute
+oscilloscope to verify GPIO toggles.
+The test passes if all driver operations execute
 correctly and provide expected functionality. Note that no direct hardware
 register access is required by the test application.
 
@@ -733,9 +733,7 @@ Module B with restricted privilege (limited hardware access).
 					
 \textbf{Input:}
 Test requests from both modules attempting to access hardware resources: (1)
-Module A requests ADC access, (2) Module B requests ADC
-access, (3) Module A requests GPIO write, (4)
-Module B requests GPIO write.
+Module A requests GPIO write, (2) Module B requests GPIO write.
 					
 \textbf{Output:}
 Module A's requests complete successfully with hardware operations executed.
@@ -746,7 +744,7 @@ denied error codes without executing hardware operations.
 Permission-based access control prevents unauthorized or unintended hardware
 operations that could compromise system safety or stability. The driver must
 enforce access policies to maintain system integrity. Only authorized components
-should control critical hardware like ADCs and display interfaces.
+should control critical hardware like PIN writes and display interfaces.
 					
 \textbf{How test will be performed:}
 Configure driver with permission rules for test modules. Execute test requests
@@ -795,7 +793,7 @@ specific error codes within timing constraints.
 					
 \textbf{Initial State:} 
 The driver layer is managing multiple memory regions for audio buffers, each
-actively being written by ADC DMA (Direct Memory Access) and read by audio
+actively being written by DMA (Direct Memory Access) and read by audio
 processing software. System is configured for continuous audio capture.
 					
 \textbf{Input:}

--- a/docs/VnVReport/VnVReport.tex
+++ b/docs/VnVReport/VnVReport.tex
@@ -194,39 +194,37 @@ baseline monitoring showed zero false positives. Maximum detection latency:
 \item{\textbf{Test-FR-2.1} Driver API functionality \\}
 
 \textbf{Input:}
-Driver API calls: (1) read ADC, (2) write GPIO, (3) configure timer, (4) read
+Driver API calls: (1) write GPIO, (2) configure timer, (3) read
 system clock.
 
 \textbf{Expected Output:}
-All operations complete successfully. ADC returns valid samples, GPIO toggles
+All operations complete successfully. GPIO toggles
 visible on oscilloscope, timer produces expected behavior, clock returns
 monotonic timestamps.
 
 \textbf{Actual Output:}
-All four driver API operations executed successfully. (1) ADC read: returned
-12-bit sample value 2048 (0.8V analog input at 3.3V reference), conversion time
-2.4$\mu$s. (2) GPIO write: toggled pin PA5 from LOW to HIGH. (3) Timer
+All four driver API operations executed successfully.
+(1) GPIO write: toggled pin PA5 from LOW to HIGH. (2) Timer
 configure: TIM2 configured to 1kHz frequency, measured output 1.000kHz $\pm$
-0.2Hz (0.02\% error). (4) System clock read: returned monotonic timestamps,
+0.2Hz (0.02\% error). (3) System clock read: returned monotonic timestamps,
 verified 1000 consecutive reads with strictly increasing values (no rollback),
-clock resolution 1$\mu$s. 100\% API call success rate (4/4 operations).
+clock resolution 1$\mu$s. 100\% API call success rate (3/3 operations).
 
 \textbf{Result:} Pass
 
 \item{\textbf{Test-FR-2.2} Permission enforcement \\}
 
 \textbf{Input:}
-Module A (high privilege) and Module B (restricted privilege) request: (1) ADC
-access, (2) GPIO write.
+Module A (high privilege) and Module B (restricted privilege) request: 
+GPIO write.
 
 \textbf{Expected Output:}
 Module A's requests succeed. Module B's requests rejected with permission denied
 error.
 
 \textbf{Actual Output:}
-Module A's ADC read succeeded, returned 12-bit sample value 2047. Module A's
-GPIO write succeeded, pin toggled (verified on oscilloscope). Module B's ADC
-read rejected with ERROR\_PERMISSION\_DENIED, return time 0.08ms. Module B's
+Module A's GPIO write succeeded, pin toggled (verified on oscilloscope).
+Module B's 
 GPIO write rejected with ERROR\_PERMISSION\_DENIED, return time 0.06ms.
 Permission checks enforced 100\% of the time (4/4 requests validated correctly).
 
@@ -1981,7 +1979,7 @@ detection \\
 \hline
 \multicolumn{3}{|l|}{\textbf{Hardware Abstraction Layer Tests}} \\
 \hline
-Test-FR-2.1 & \hyperref[SRS-FR2_1]{FR-2.1} & Peripheral interface testing (ADC,
+Test-FR-2.1 & \hyperref[SRS-FR2_1]{FR-2.1} & Peripheral interface testing (
 GPIO, timer, clock) \\
 \hline
 Test-FR-2.2 & \hyperref[SRS-FR2_2]{FR-2.2} & Permission enforcement for HAL
@@ -2147,7 +2145,7 @@ Test-FR-1.3 & Memory Manager & Allocation, deallocation, limit enforcement \\
 Test-FR-1.4 & \hyperref[MG-mMicDiag]{M4} & Diagnostic fault detection and
 reporting \\
 \hline
-Test-FR-2.1 & HAL Interface & ADC, GPIO, timer, clock peripheral access \\
+Test-FR-2.1 & HAL Interface & GPIO, timer, clock peripheral access \\
 \hline
 Test-FR-2.2 & HAL Interface & Permission-based access control \\
 \hline


### PR DESCRIPTION
## 📝 Summary

Remove ADC from documentations since they come on microphone already

## 🎯 Related Issues

- closes #363 
