### PR TITLE
[Peer Review Feedback] Add clarification on baseline

### DIFF
--- a/docs/VnVReport/VnVReport.tex
+++ b/docs/VnVReport/VnVReport.tex
@@ -340,7 +340,9 @@ IntegerCyclesMinimalLeakage. All completed in 1 ms total.
 
 \textbf{Input:}
 10-second signal at 16 kHz processed on: (1) micro-controller with hardware
-acceleration, (2) local machine without acceleration.
+acceleration, (2) local machine without acceleration. The laptop implementation
+is used only as a reference baseline since hardware capabilities differ 
+significantly between the two platforms.
 
 \textbf{Expected Output:}
 Both produce equivalent spectrograms ($\leq$ 0.1\% amplitude error).


### PR DESCRIPTION
## 📝 Summary

Added clarification sentence to address why laptop is used as a baseline only due to the platform specification differences. 

## 🎯 Related Issues

- closes #604
